### PR TITLE
Encapsulate Credentials behind a standard interface.

### DIFF
--- a/dnsimple/authentication.go
+++ b/dnsimple/authentication.go
@@ -1,0 +1,88 @@
+package dnsimple
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+const (
+	httpHeaderDomainToken   = "X-DNSimple-Domain-Token"
+	httpHeaderApiToken      = "X-DNSimple-Token"
+	httpHeaderAuthorization = "Authorization"
+)
+
+// Provides credentials that can be used for authenticating with DNSimple
+//
+// More information on credentials may be found here:
+//   http://developer.dnsimple.com/v2/#authentication
+type Credentials interface {
+	// Get the HTTP header key and value to use for authentication.
+	HttpHeader() (string, string)
+}
+
+// Domain token authentication
+
+type domainTokenCredentials struct {
+	domainToken string
+}
+
+// Construct Credentials using the DNSimple Domain Token method
+func NewDomainTokenCredentials(domainToken string) Credentials {
+	return &domainTokenCredentials{domainToken: domainToken}
+}
+
+func (c *domainTokenCredentials) HttpHeader() (string, string) {
+	return httpHeaderDomainToken, c.domainToken
+}
+
+// HTTP basic authentication
+
+type httpBasicCredentials struct {
+	email    string
+	password string
+}
+
+// Construct Credentials using HTTP Basic Auth
+func NewHttpBasicCredentials(email, password string) Credentials {
+	return &httpBasicCredentials{email, password}
+}
+
+func (c *httpBasicCredentials) HttpHeader() (string, string) {
+	return httpHeaderAuthorization, "Basic " + basicAuth(c.email, c.password)
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+// API token authentication
+
+type apiTokenCredentials struct {
+	email    string
+	apiToken string
+}
+
+// Construct Credentials using the API Token method.
+func NewApiTokenCredentials(email, apiToken string) Credentials {
+	return &apiTokenCredentials{email: email, apiToken: apiToken}
+}
+
+func (c *apiTokenCredentials) HttpHeader() (string, string) {
+	return httpHeaderApiToken, fmt.Sprintf("%v:%v", c.email, c.apiToken)
+}
+
+// OAuth token authentication
+
+type oauthTokenCredentials struct {
+	oauthToken string
+}
+
+// Construct Credentials using an OAuth token.
+func NewOauthTokenCredentials(oauthToken string) Credentials {
+	return &oauthTokenCredentials{oauthToken: oauthToken}
+}
+
+func (c *oauthTokenCredentials) HttpHeader() (string, string) {
+	return httpHeaderAuthorization, "Bearer " + c.oauthToken
+}

--- a/dnsimple/authentication.go
+++ b/dnsimple/authentication.go
@@ -71,18 +71,3 @@ func NewApiTokenCredentials(email, apiToken string) Credentials {
 func (c *apiTokenCredentials) HttpHeader() (string, string) {
 	return httpHeaderApiToken, fmt.Sprintf("%v:%v", c.email, c.apiToken)
 }
-
-// OAuth token authentication
-
-type oauthTokenCredentials struct {
-	oauthToken string
-}
-
-// Construct Credentials using an OAuth token.
-func NewOauthTokenCredentials(oauthToken string) Credentials {
-	return &oauthTokenCredentials{oauthToken: oauthToken}
-}
-
-func (c *oauthTokenCredentials) HttpHeader() (string, string) {
-	return httpHeaderAuthorization, "Bearer " + c.oauthToken
-}

--- a/dnsimple/authentication_test.go
+++ b/dnsimple/authentication_test.go
@@ -35,10 +35,3 @@ func TestApiTokenCredentialsHttpHeader(t *testing.T) {
 	expectedHeaderValue := fmt.Sprintf("%v:%v", email, apiToken)
 	testCredentials(t, credentials, httpHeaderApiToken, expectedHeaderValue)
 }
-
-func TestOauthTokenCredentialsHttpHeader(t *testing.T) {
-	oauthToken := "oauth-token"
-	credentials := NewOauthTokenCredentials(oauthToken)
-	expectedHeaderValue := fmt.Sprintf("Bearer %v", oauthToken)
-	testCredentials(t, credentials, httpHeaderAuthorization, expectedHeaderValue)
-}

--- a/dnsimple/authentication_test.go
+++ b/dnsimple/authentication_test.go
@@ -1,0 +1,44 @@
+package dnsimple
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testCredentials(t *testing.T, credentials Credentials, expectedName, expectedValue string) {
+	headerName, headerValue := credentials.HttpHeader()
+	if headerName != expectedName {
+		t.Errorf("Header name: %v, want %v", headerName, expectedName)
+	}
+
+	if headerValue != expectedValue {
+		t.Errorf("Header value: %v, want %v", headerValue, expectedValue)
+	}
+}
+
+func TestDomainTokenCredentialsHttpHeader(t *testing.T) {
+	domainToken := "domain-token"
+	credentials := NewDomainTokenCredentials(domainToken)
+	testCredentials(t, credentials, httpHeaderDomainToken, domainToken)
+}
+
+func TestHttpBasicCredentialsHttpHeader(t *testing.T) {
+	email, password := "email", "password"
+	credentials := NewHttpBasicCredentials(email, password)
+	expectedHeaderValue := "Basic ZW1haWw6cGFzc3dvcmQ="
+	testCredentials(t, credentials, httpHeaderAuthorization, expectedHeaderValue)
+}
+
+func TestApiTokenCredentialsHttpHeader(t *testing.T) {
+	email, apiToken := "email", "api-token"
+	credentials := NewApiTokenCredentials(email, apiToken)
+	expectedHeaderValue := fmt.Sprintf("%v:%v", email, apiToken)
+	testCredentials(t, credentials, httpHeaderApiToken, expectedHeaderValue)
+}
+
+func TestOauthTokenCredentialsHttpHeader(t *testing.T) {
+	oauthToken := "oauth-token"
+	credentials := NewOauthTokenCredentials(oauthToken)
+	expectedHeaderValue := fmt.Sprintf("Bearer %v", oauthToken)
+	testCredentials(t, credentials, httpHeaderAuthorization, expectedHeaderValue)
+}

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -44,13 +44,8 @@ type Client struct {
 
 // NewClient returns a new DNSimple API client.
 func NewClient(apiToken, email string) *Client {
-	credentials := NewApiTokenCredentials(email, apiToken)
-	c := &Client{Credentials: credentials, HttpClient: &http.Client{}, BaseURL: baseURL, UserAgent: userAgent}
-	c.Contacts = &ContactsService{client: c}
-	c.Domains = &DomainsService{client: c}
-	c.Registrar = &RegistrarService{client: c}
-	c.Users = &UsersService{client: c}
-	return c
+	return NewAuthenticatedClient(NewApiTokenCredentials(email, apiToken))
+
 }
 
 // NewAuthenticatedClient returns a new DNSimple API client  using the given

--- a/dnsimple/dnsimple_test.go
+++ b/dnsimple/dnsimple_test.go
@@ -84,7 +84,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewAuthenticatedClient(t *testing.T) {
-	c := NewAuthenticatedClient(NewOauthTokenCredentials("oauth-token"))
+	c := NewAuthenticatedClient(NewApiTokenCredentials("me@example.com", "mytoken"))
 
 	if c.BaseURL != baseURL {
 		t.Errorf("NewClient BaseURL = %v, want %v", c.BaseURL, baseURL)

--- a/dnsimple/dnsimple_test.go
+++ b/dnsimple/dnsimple_test.go
@@ -83,6 +83,14 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewAuthenticatedClient(t *testing.T) {
+	c := NewAuthenticatedClient(NewOauthTokenCredentials("oauth-token"))
+
+	if c.BaseURL != baseURL {
+		t.Errorf("NewClient BaseURL = %v, want %v", c.BaseURL, baseURL)
+	}
+}
+
 func TestNewRequest(t *testing.T) {
 	c := NewClient("mytoken", "me@example.com")
 	c.BaseURL = "https://go.example.com/"


### PR DESCRIPTION
Credentials should be constructed using the various constructor functions. All constructors return the
Credentials interface which may be passed when creating a new client using the NewAuthenticatedClient() function.

I have retained backwards compatibility by leaving the existing NewClient() function in place for now.